### PR TITLE
mongo: trace all with OpenCensus

### DIFF
--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -1,0 +1,81 @@
+// Copyright (C) MongoDB, Inc. 2018-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package trace
+
+import (
+	"context"
+	"runtime"
+	"strings"
+	"sync"
+
+	"go.opencensus.io/trace"
+)
+
+// The purpose of baseCommonName is to help trim out the Longest Common Prefix
+// so that different spans will have disambiguated names e.g.
+//    mongo.(*Collection).InsertOne
+// instead of:
+//    github.com/mongodb/mongo-go-driver/mongo.(*Collection).InsertOne
+// in a non-invasive way.
+func caller0() string {
+	pc, _, _, _ := runtime.Caller(0)
+	fn := runtime.FuncForPC(pc)
+	return fn.Name()
+}
+
+var baseCommonPath = caller0()
+
+var lcpCacheMtx sync.Mutex
+var lcpCache = make(map[string]string)
+
+func longestCommonPrefix(p1, p2 string) string {
+	// In the common case we'll have the same base path hence
+	// we should start checking from the end
+	min, max := p1, p2
+	if len(max) < len(min) {
+		min, max = max, min
+	}
+	for i := 0; i < len(min); i++ {
+		if max[i] != min[i] {
+			return min[:i]
+		}
+	}
+	return min
+}
+
+func SpanFromFunctionCaller(ctx context.Context) (context.Context, *trace.Span) {
+	// The call to relativeName is an extra
+	// function call away from the original.
+	nCallers := 2
+	return trace.StartSpan(ctx, relativeName(nCallers))
+}
+
+func SpanWithName(ctx context.Context, name string) (context.Context, *trace.Span) {
+	return trace.StartSpan(ctx, name)
+}
+
+func RelativeName() string {
+	return relativeName(2)
+}
+
+func relativeName(nCaller int) string {
+	pc, _, _, _ := runtime.Caller(nCaller)
+	fn := runtime.FuncForPC(pc)
+	fnName := fn.Name()
+	lcpName, ok := lcpCache[fnName]
+
+	if !ok {
+		lcpCacheMtx.Lock()
+		disambiguatedPrefix := longestCommonPrefix(baseCommonPath, fnName)
+		trimmed := strings.TrimPrefix(fnName, disambiguatedPrefix)
+		lcpCache[fnName] = trimmed
+		lcpName = trimmed
+		lcpCacheMtx.Unlock()
+	}
+
+	return lcpName
+}

--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/mongodb/mongo-go-driver/bson"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 	"github.com/mongodb/mongo-go-driver/mongo/private/cluster"
 	"github.com/mongodb/mongo-go-driver/mongo/private/ops"
 	"github.com/mongodb/mongo-go-driver/mongo/private/options"
@@ -62,10 +63,16 @@ func (coll *Collection) namespace() ops.Namespace {
 }
 
 func (coll *Collection) getWriteableServer(ctx context.Context) (*ops.SelectedServer, error) {
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	return coll.client.selectServer(ctx, coll.writeSelector, readpref.Primary())
 }
 
 func (coll *Collection) getReadableServer(ctx context.Context) (*ops.SelectedServer, error) {
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	return coll.client.selectServer(ctx, coll.readSelector, coll.readPreference)
 }
 
@@ -84,6 +91,9 @@ func (coll *Collection) InsertOne(ctx context.Context, document interface{},
 	if ctx == nil {
 		ctx = context.Background()
 	}
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	doc, err := TransformDocument(document)
 	if err != nil {
@@ -163,6 +173,9 @@ func (coll *Collection) InsertMany(ctx context.Context, documents []interface{},
 	if ctx == nil {
 		ctx = context.Background()
 	}
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	result := make([]interface{}, len(documents))
 	docs := make([]*bson.Document, len(documents))
@@ -246,6 +259,9 @@ func (coll *Collection) DeleteOne(ctx context.Context, filter interface{},
 		ctx = context.Background()
 	}
 
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	f, err := TransformDocument(filter)
 	if err != nil {
 		return nil, err
@@ -300,7 +316,9 @@ func (coll *Collection) DeleteOne(ctx context.Context, filter interface{},
 		return nil, err
 	}
 
+	_, decodeSpan := trace.SpanWithName(ctx, "bson.NewDecoder.Decode")
 	err = bson.NewDecoder(bytes.NewReader(rdr)).Decode(&result)
+	decodeSpan.End()
 	if err != nil {
 		return nil, err
 	}
@@ -321,6 +339,9 @@ func (coll *Collection) DeleteMany(ctx context.Context, filter interface{},
 	if ctx == nil {
 		ctx = context.Background()
 	}
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	f, err := TransformDocument(filter)
 	if err != nil {
@@ -386,6 +407,9 @@ func (coll *Collection) updateOrReplaceOne(ctx context.Context, filter,
 	if ctx == nil {
 		ctx = context.Background()
 	}
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	updateDocs := []*bson.Document{
 		bson.NewDocument(
@@ -464,6 +488,9 @@ func (coll *Collection) UpdateOne(ctx context.Context, filter interface{}, updat
 		ctx = context.Background()
 	}
 
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	f, err := TransformDocument(filter)
 	if err != nil {
 		return nil, err
@@ -493,6 +520,9 @@ func (coll *Collection) UpdateMany(ctx context.Context, filter interface{}, upda
 	if ctx == nil {
 		ctx = context.Background()
 	}
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	f, err := TransformDocument(filter)
 	if err != nil {
@@ -585,6 +615,9 @@ func (coll *Collection) ReplaceOne(ctx context.Context, filter interface{},
 		ctx = context.Background()
 	}
 
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	f, err := TransformDocument(filter)
 	if err != nil {
 		return nil, err
@@ -621,6 +654,9 @@ func (coll *Collection) Aggregate(ctx context.Context, pipeline interface{},
 	if ctx == nil {
 		ctx = context.Background()
 	}
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	pipelineArr, err := transformAggregatePipeline(pipeline)
 	if err != nil {
@@ -701,6 +737,10 @@ func (coll *Collection) Aggregate(ctx context.Context, pipeline interface{},
 
 func (coll *Collection) aggregateWithServer(ctx context.Context, server *ops.SelectedServer,
 	pipeline *bson.Array, opts ...options.AggregateOptioner) (Cursor, error) {
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	if coll.readConcern != nil {
 		rc, err := Opt.ReadConcern(coll.readConcern)
 		if err != nil {
@@ -725,6 +765,9 @@ func (coll *Collection) Count(ctx context.Context, filter interface{},
 	if ctx == nil {
 		ctx = context.Background()
 	}
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	f, err := TransformDocument(filter)
 	if err != nil {
@@ -766,6 +809,9 @@ func (coll *Collection) Distinct(ctx context.Context, fieldName string, filter i
 	if ctx == nil {
 		ctx = context.Background()
 	}
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	var f *bson.Document
 	var err error
@@ -820,6 +866,9 @@ func (coll *Collection) Find(ctx context.Context, filter interface{},
 		ctx = context.Background()
 	}
 
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	var f *bson.Document
 	var err error
 	if filter != nil {
@@ -872,6 +921,9 @@ func (coll *Collection) FindOne(ctx context.Context, filter interface{},
 		ctx = context.Background()
 	}
 
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	var f *bson.Document
 	var err error
 	if filter != nil {
@@ -913,6 +965,9 @@ func (coll *Collection) FindOneAndDelete(ctx context.Context, filter interface{}
 	if ctx == nil {
 		ctx = context.Background()
 	}
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	var f *bson.Document
 	var err error
@@ -982,6 +1037,9 @@ func (coll *Collection) FindOneAndReplace(ctx context.Context, filter interface{
 	if ctx == nil {
 		ctx = context.Background()
 	}
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	f, err := TransformDocument(filter)
 	if err != nil {
@@ -1058,6 +1116,9 @@ func (coll *Collection) FindOneAndUpdate(ctx context.Context, filter interface{}
 		ctx = context.Background()
 	}
 
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	f, err := TransformDocument(filter)
 	if err != nil {
 		return &DocumentResult{err: err}
@@ -1122,6 +1183,9 @@ func (coll *Collection) FindOneAndUpdate(ctx context.Context, filter interface{}
 // supports resumability in the case of some errors.
 func (coll *Collection) Watch(ctx context.Context, pipeline interface{},
 	opts ...options.ChangeStreamOptioner) (Cursor, error) {
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	return newChangeStream(ctx, coll, pipeline, opts...)
 }
 

--- a/mongo/database.go
+++ b/mongo/database.go
@@ -10,6 +10,7 @@ import (
 	"context"
 
 	"github.com/mongodb/mongo-go-driver/bson"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 	"github.com/mongodb/mongo-go-driver/mongo/private/cluster"
 	"github.com/mongodb/mongo-go-driver/mongo/private/ops"
 	"github.com/mongodb/mongo-go-driver/mongo/readconcern"
@@ -71,6 +72,9 @@ func (db *Database) RunCommand(ctx context.Context, command interface{}) (bson.R
 	if ctx == nil {
 		ctx = context.Background()
 	}
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	s, err := db.client.selectServer(ctx, readpref.Selector(readpref.Primary()), readpref.Primary())
 	if err != nil {

--- a/mongo/index_view.go
+++ b/mongo/index_view.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongo-go-driver/bson"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 	"github.com/mongodb/mongo-go-driver/mongo/private/ops"
 )
 
@@ -32,6 +33,9 @@ type IndexModel struct {
 
 // List returns a cursor iterating over all the indexes in the collection.
 func (iv IndexView) List(ctx context.Context) (Cursor, error) {
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	s, err := iv.coll.getWriteableServer(ctx)
 	if err != nil {
 		return nil, err
@@ -42,6 +46,9 @@ func (iv IndexView) List(ctx context.Context) (Cursor, error) {
 
 // CreateOne creates a single index in the collection specified by the model.
 func (iv IndexView) CreateOne(ctx context.Context, model IndexModel) (string, error) {
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	names, err := iv.CreateMany(ctx, model)
 	if err != nil {
 		return "", err
@@ -53,6 +60,9 @@ func (iv IndexView) CreateOne(ctx context.Context, model IndexModel) (string, er
 // CreateMany creates multiple indexes in the collection specified by the models. The names of the
 // creates indexes are returned.
 func (iv IndexView) CreateMany(ctx context.Context, models ...IndexModel) ([]string, error) {
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	names := make([]string, 0, len(models))
 	indexes := bson.NewArray()
 
@@ -93,6 +103,9 @@ func (iv IndexView) CreateMany(ctx context.Context, models ...IndexModel) ([]str
 
 // DropOne drops the index with the given name from the collection.
 func (iv IndexView) DropOne(ctx context.Context, name string) (bson.Reader, error) {
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	if name == "*" {
 		return nil, ErrMultipleIndexDrop
 	}
@@ -107,6 +120,9 @@ func (iv IndexView) DropOne(ctx context.Context, name string) (bson.Reader, erro
 
 // DropAll drops all indexes in the collection.
 func (iv IndexView) DropAll(ctx context.Context) (bson.Reader, error) {
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	s, err := iv.coll.getWriteableServer(ctx)
 	if err != nil {
 		return nil, err

--- a/mongo/private/auth/default.go
+++ b/mongo/private/auth/default.go
@@ -9,6 +9,7 @@ package auth
 import (
 	"context"
 
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 	"github.com/mongodb/mongo-go-driver/mongo/internal/feature"
 	"github.com/mongodb/mongo-go-driver/mongo/private/conn"
 )
@@ -27,6 +28,9 @@ type DefaultAuthenticator struct {
 
 // Auth authenticates the connection.
 func (a *DefaultAuthenticator) Auth(ctx context.Context, c conn.Connection) error {
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	var actual Authenticator
 	var err error
 	if err = feature.ScramSHA1(c.Model().Version); err != nil {

--- a/mongo/private/auth/mongodbcr.go
+++ b/mongo/private/auth/mongodbcr.go
@@ -15,6 +15,7 @@ import (
 	"io"
 
 	"github.com/mongodb/mongo-go-driver/bson"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 	"github.com/mongodb/mongo-go-driver/mongo/model"
 	"github.com/mongodb/mongo-go-driver/mongo/private/conn"
 	"github.com/mongodb/mongo-go-driver/mongo/private/msg"
@@ -40,6 +41,9 @@ type MongoDBCRAuthenticator struct {
 
 // Auth authenticates the connection.
 func (a *MongoDBCRAuthenticator) Auth(ctx context.Context, c conn.Connection) error {
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	// Arbiters cannot be authenticated
 	if c.Model().Kind == model.RSArbiter {

--- a/mongo/private/auth/plain.go
+++ b/mongo/private/auth/plain.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 	"github.com/mongodb/mongo-go-driver/mongo/private/conn"
 )
 
@@ -35,6 +36,9 @@ type PlainAuthenticator struct {
 
 // Auth authenticates the connection.
 func (a *PlainAuthenticator) Auth(ctx context.Context, c conn.Connection) error {
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	return ConductSaslConversation(ctx, c, "$external", &plainSaslClient{
 		username: a.Username,
 		password: a.Password,

--- a/mongo/private/auth/sasl.go
+++ b/mongo/private/auth/sasl.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mongodb/mongo-go-driver/mongo/model"
 
 	"github.com/mongodb/mongo-go-driver/bson"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 	"github.com/mongodb/mongo-go-driver/mongo/private/conn"
 	"github.com/mongodb/mongo-go-driver/mongo/private/msg"
 )
@@ -32,6 +33,9 @@ type SaslClientCloser interface {
 
 // ConductSaslConversation handles running a sasl conversation with MongoDB.
 func ConductSaslConversation(ctx context.Context, c conn.Connection, db string, client SaslClient) error {
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	// Arbiters cannot be authenticated
 	if c.Model().Kind == model.RSArbiter {

--- a/mongo/private/auth/scramsha1.go
+++ b/mongo/private/auth/scramsha1.go
@@ -22,6 +22,7 @@ import (
 
 	"encoding/base64"
 
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 	"github.com/mongodb/mongo-go-driver/mongo/private/conn"
 )
 
@@ -51,6 +52,9 @@ type ScramSHA1Authenticator struct {
 
 // Auth authenticates the connection.
 func (a *ScramSHA1Authenticator) Auth(ctx context.Context, c conn.Connection) error {
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	client := &scramSaslClient{
 		username:       a.Username,
 		password:       a.Password,

--- a/mongo/private/auth/x509.go
+++ b/mongo/private/auth/x509.go
@@ -10,6 +10,7 @@ import (
 	"context"
 
 	"github.com/mongodb/mongo-go-driver/bson"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 	"github.com/mongodb/mongo-go-driver/mongo/private/conn"
 	"github.com/mongodb/mongo-go-driver/mongo/private/msg"
 )
@@ -28,6 +29,10 @@ type MongoDBX509Authenticator struct {
 
 // Auth implements the Authenticator interface.
 func (a *MongoDBX509Authenticator) Auth(ctx context.Context, c conn.Connection) error {
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	authRequestDoc := bson.NewDocument(
 		bson.EC.Int32("authenticate", 1),
 		bson.EC.String("mechanism", MongoDBX509),

--- a/mongo/private/cluster/cluster.go
+++ b/mongo/private/cluster/cluster.go
@@ -12,6 +12,7 @@ import (
 	"math/rand"
 	"sync"
 
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 	"github.com/mongodb/mongo-go-driver/mongo/internal"
 	"github.com/mongodb/mongo-go-driver/mongo/model"
 	"github.com/mongodb/mongo-go-driver/mongo/private/ops"
@@ -119,6 +120,9 @@ func (c *Cluster) Model() *model.Cluster {
 func (c *Cluster) SelectServer(ctx context.Context, selector ServerSelector,
 	readPreference *readpref.ReadPref) (*ops.SelectedServer, error) {
 
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	for {
 		suitable, err := SelectServers(ctx, c.monitor, selector)
 		if err != nil {
@@ -161,6 +165,9 @@ func SelectServers(ctx context.Context, m *Monitor, selector ServerSelector) ([]
 func selectServers(ctx context.Context, m monitor, selector ServerSelector) ([]*model.Server, error) {
 	updates, unsubscribe, _ := m.Subscribe()
 	defer unsubscribe()
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	var current *model.Cluster
 	for {

--- a/mongo/private/conn/net.go
+++ b/mongo/private/conn/net.go
@@ -9,12 +9,17 @@ package conn
 import (
 	"context"
 	"net"
+
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 )
 
 // Dialer dials a server according to the network and address.
 type Dialer func(ctx context.Context, dialer *net.Dialer, network, address string) (net.Conn, error)
 
 func dialWithoutTLS(ctx context.Context, dialer *net.Dialer, network, address string) (net.Conn, error) {
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	conn, err := dialer.DialContext(ctx, network, address)
 	if err != nil {
 		return nil, err

--- a/mongo/private/conn/protocol.go
+++ b/mongo/private/conn/protocol.go
@@ -11,12 +11,16 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongo-go-driver/bson"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 	"github.com/mongodb/mongo-go-driver/mongo/internal"
 	"github.com/mongodb/mongo-go-driver/mongo/private/msg"
 )
 
 // ExecuteCommand executes the message on the channel.
 func ExecuteCommand(ctx context.Context, c Connection, request msg.Request) (bson.Reader, error) {
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	readers, err := ExecuteCommands(ctx, c, []msg.Request{request})
 	if err != nil {
 		return nil, err

--- a/mongo/private/conn/tracked.go
+++ b/mongo/private/conn/tracked.go
@@ -9,6 +9,7 @@ package conn
 import (
 	"context"
 
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 	"github.com/mongodb/mongo-go-driver/mongo/model"
 	"github.com/mongodb/mongo-go-driver/mongo/private/msg"
 )
@@ -60,10 +61,16 @@ func (tc *TrackedConnection) Inc() {
 
 // Read reads a message from the connection.
 func (tc *TrackedConnection) Read(ctx context.Context, responseTo int32) (msg.Response, error) {
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	return tc.c.Read(ctx, responseTo)
 }
 
 // Write writes a number of messages to the connection.
 func (tc *TrackedConnection) Write(ctx context.Context, reqs ...msg.Request) error {
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	return tc.c.Write(ctx, reqs...)
 }

--- a/mongo/private/ops/aggregate.go
+++ b/mongo/private/ops/aggregate.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/mongodb/mongo-go-driver/bson"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 	"github.com/mongodb/mongo-go-driver/mongo/internal"
 	"github.com/mongodb/mongo-go-driver/mongo/private/options"
 )
@@ -21,6 +22,9 @@ import (
 // the appropriate parameter based on whether there is a $out in the pipeline.
 func Aggregate(ctx context.Context, s *SelectedServer, ns Namespace, pipeline *bson.Array,
 	hasDollarOut bool, opts ...options.AggregateOptioner) (Cursor, error) {
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	if err := ns.validate(); err != nil {
 		return nil, err
@@ -72,6 +76,10 @@ type AggregationOptions struct {
 //
 // The pipeline must encode as a BSON array of pipeline stages.
 func LegacyAggregate(ctx context.Context, s *SelectedServer, ns Namespace, pipeline *bson.Array, options AggregationOptions) (Cursor, error) {
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	if err := ns.validate(); err != nil {
 		return nil, err
 	}

--- a/mongo/private/ops/count.go
+++ b/mongo/private/ops/count.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 
 	"github.com/mongodb/mongo-go-driver/bson"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 	"github.com/mongodb/mongo-go-driver/mongo/internal"
 	"github.com/mongodb/mongo-go-driver/mongo/private/options"
 )
@@ -18,6 +19,9 @@ import (
 // Count counts how many documents in a collection match a given query.
 func Count(ctx context.Context, s *SelectedServer, ns Namespace, query *bson.Document,
 	opts ...options.CountOptioner) (int64, error) {
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	if err := ns.validate(); err != nil {
 		return 0, err

--- a/mongo/private/ops/create_indexes.go
+++ b/mongo/private/ops/create_indexes.go
@@ -10,11 +10,15 @@ import (
 	"context"
 
 	"github.com/mongodb/mongo-go-driver/bson"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 )
 
 // CreateIndexes creates one or more index in a collection.
 func CreateIndexes(ctx context.Context, s *SelectedServer, ns Namespace,
 	indexes *bson.Array) error {
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	listIndexesCommand := bson.NewDocument(
 		bson.EC.String("createIndexes", ns.Collection),

--- a/mongo/private/ops/cursor.go
+++ b/mongo/private/ops/cursor.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongo-go-driver/bson"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 	"github.com/mongodb/mongo-go-driver/mongo/internal"
 	"github.com/mongodb/mongo-go-driver/mongo/private/conn"
 	"github.com/mongodb/mongo-go-driver/mongo/private/msg"
@@ -143,6 +144,9 @@ func (c *cursorImpl) ID() int64 {
 }
 
 func (c *cursorImpl) Next(ctx context.Context) bool {
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	// TODO(skriptble): This is really messy, needs to be redesigned.
 	c.current++
 	if c.current < c.currentBatch.Len() {
@@ -186,6 +190,9 @@ func (c *cursorImpl) Err() error {
 
 // TODO(GODRIVER-256): Only return the underlying Close error.
 func (c *cursorImpl) Close(ctx context.Context) error {
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	if c.cursorID == 0 {
 		return c.err
 	}
@@ -233,6 +240,9 @@ func (c *cursorImpl) Close(ctx context.Context) error {
 }
 
 func (c *cursorImpl) getMore(ctx context.Context) {
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	c.currentBatch.Reset()
 	c.current = 0
 

--- a/mongo/private/ops/delete.go
+++ b/mongo/private/ops/delete.go
@@ -10,6 +10,7 @@ import (
 	"context"
 
 	"github.com/mongodb/mongo-go-driver/bson"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 	"github.com/mongodb/mongo-go-driver/mongo/internal"
 	"github.com/mongodb/mongo-go-driver/mongo/private/options"
 )
@@ -17,6 +18,9 @@ import (
 // Delete executes an delete command with a given set of delete documents and options.
 func Delete(ctx context.Context, s *SelectedServer, ns Namespace, deleteDocs []*bson.Document,
 	opts ...options.DeleteOptioner) (bson.Reader, error) {
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	if err := ns.validate(); err != nil {
 		return nil, err

--- a/mongo/private/ops/distinct.go
+++ b/mongo/private/ops/distinct.go
@@ -11,6 +11,7 @@ import (
 	"context"
 
 	"github.com/mongodb/mongo-go-driver/bson"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 	"github.com/mongodb/mongo-go-driver/mongo/internal"
 	"github.com/mongodb/mongo-go-driver/mongo/private/options"
 )
@@ -18,6 +19,9 @@ import (
 // Distinct returns the distinct values for a specified field across a single collection.
 func Distinct(ctx context.Context, s *SelectedServer, ns Namespace, field string,
 	query *bson.Document, opts ...options.DistinctOptioner) ([]interface{}, error) {
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	if err := ns.validate(); err != nil {
 		return nil, err

--- a/mongo/private/ops/drop_indexes.go
+++ b/mongo/private/ops/drop_indexes.go
@@ -10,11 +10,15 @@ import (
 	"context"
 
 	"github.com/mongodb/mongo-go-driver/bson"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 )
 
 // DropIndexes drops one or all of the indexes in a collection.
 func DropIndexes(ctx context.Context, s *SelectedServer, ns Namespace,
 	index string) (bson.Reader, error) {
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	listIndexesCommand := bson.NewDocument(
 		bson.EC.String("dropIndexes", ns.Collection),

--- a/mongo/private/ops/find.go
+++ b/mongo/private/ops/find.go
@@ -10,6 +10,7 @@ import (
 	"context"
 
 	"github.com/mongodb/mongo-go-driver/bson"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 	"github.com/mongodb/mongo-go-driver/mongo/internal"
 	"github.com/mongodb/mongo-go-driver/mongo/private/options"
 )
@@ -17,6 +18,9 @@ import (
 // Find executes a query.
 func Find(ctx context.Context, s *SelectedServer, ns Namespace, filter *bson.Document,
 	findOptions ...options.FindOptioner) (Cursor, error) {
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	if err := ns.validate(); err != nil {
 		return nil, err

--- a/mongo/private/ops/find_one_and_delete.go
+++ b/mongo/private/ops/find_one_and_delete.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 
 	"github.com/mongodb/mongo-go-driver/bson"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 	"github.com/mongodb/mongo-go-driver/mongo/internal"
 	"github.com/mongodb/mongo-go-driver/mongo/private/options"
 )
@@ -18,6 +19,9 @@ import (
 // FindOneAndDelete modifies and returns a single document.
 func FindOneAndDelete(ctx context.Context, s *SelectedServer, ns Namespace, query *bson.Document,
 	opts ...options.FindOneAndDeleteOptioner) (Cursor, error) {
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	if err := ns.validate(); err != nil {
 		return nil, err

--- a/mongo/private/ops/find_one_and_replace.go
+++ b/mongo/private/ops/find_one_and_replace.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 
 	"github.com/mongodb/mongo-go-driver/bson"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 	"github.com/mongodb/mongo-go-driver/mongo/internal"
 	"github.com/mongodb/mongo-go-driver/mongo/private/options"
 )
@@ -18,6 +19,9 @@ import (
 // FindOneAndReplace modifies and returns a single document.
 func FindOneAndReplace(ctx context.Context, s *SelectedServer, ns Namespace, query *bson.Document,
 	replacement *bson.Document, opts ...options.FindOneAndReplaceOptioner) (Cursor, error) {
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	if err := ns.validate(); err != nil {
 		return nil, err

--- a/mongo/private/ops/find_one_and_update.go
+++ b/mongo/private/ops/find_one_and_update.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 
 	"github.com/mongodb/mongo-go-driver/bson"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 	"github.com/mongodb/mongo-go-driver/mongo/internal"
 	"github.com/mongodb/mongo-go-driver/mongo/private/options"
 )
@@ -18,6 +19,9 @@ import (
 // FindOneAndUpdate modifies and returns a single document.
 func FindOneAndUpdate(ctx context.Context, s *SelectedServer, ns Namespace, query *bson.Document,
 	update *bson.Document, opts ...options.FindOneAndUpdateOptioner) (Cursor, error) {
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	if err := ns.validate(); err != nil {
 		return nil, err

--- a/mongo/private/ops/insert.go
+++ b/mongo/private/ops/insert.go
@@ -10,6 +10,7 @@ import (
 	"context"
 
 	"github.com/mongodb/mongo-go-driver/bson"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 	"github.com/mongodb/mongo-go-driver/mongo/internal"
 	"github.com/mongodb/mongo-go-driver/mongo/private/options"
 )
@@ -17,6 +18,9 @@ import (
 // Insert executes an insert command for the given set of  documents.
 func Insert(ctx context.Context, s *SelectedServer, ns Namespace, docs []*bson.Document,
 	options ...options.InsertOptioner) (rdr bson.Reader, err error) {
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	if err := ns.validate(); err != nil {
 		return nil, err

--- a/mongo/private/ops/kill_cursors.go
+++ b/mongo/private/ops/kill_cursors.go
@@ -10,12 +10,16 @@ import (
 	"context"
 
 	"github.com/mongodb/mongo-go-driver/bson"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 	"github.com/mongodb/mongo-go-driver/mongo/internal"
 )
 
 // KillCursors kills one or more cursors.
 func KillCursors(ctx context.Context, s *SelectedServer, ns Namespace,
 	cursors []int64) (bson.Reader, error) {
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	if err := ns.validate(); err != nil {
 		return nil, err

--- a/mongo/private/ops/list_collections.go
+++ b/mongo/private/ops/list_collections.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/mongodb/mongo-go-driver/bson"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 )
 
 // ListCollectionsOptions are the options for listing collections.
@@ -25,6 +26,10 @@ type ListCollectionsOptions struct {
 
 // ListCollections lists the collections in the given database with the given options.
 func ListCollections(ctx context.Context, s *SelectedServer, db string, options ListCollectionsOptions) (Cursor, error) {
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	if err := validateDB(db); err != nil {
 		return nil, err
 	}

--- a/mongo/private/ops/list_databases.go
+++ b/mongo/private/ops/list_databases.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/mongodb/mongo-go-driver/bson"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 )
 
 // ListDatabasesOptions are the options for listing databases.
@@ -27,6 +28,9 @@ type ListDatabasesOptions struct {
 // ListDatabases lists the databases with the given options
 func ListDatabases(ctx context.Context, s *SelectedServer, filter *bson.Document,
 	options ListDatabasesOptions) (Cursor, error) {
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	listDatabasesCommand := bson.NewDocument(
 		bson.EC.Int32("listDatabases", 1))

--- a/mongo/private/ops/list_indexes.go
+++ b/mongo/private/ops/list_indexes.go
@@ -10,6 +10,7 @@ import (
 	"context"
 
 	"github.com/mongodb/mongo-go-driver/bson"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 	"github.com/mongodb/mongo-go-driver/mongo/private/conn"
 )
 
@@ -21,6 +22,9 @@ type ListIndexesOptions struct {
 
 // ListIndexes lists the indexes on the given namespace.
 func ListIndexes(ctx context.Context, s *SelectedServer, ns Namespace, options ListIndexesOptions) (Cursor, error) {
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	listIndexesCommand := bson.NewDocument(bson.EC.String("listIndexes", ns.Collection))
 

--- a/mongo/private/ops/run.go
+++ b/mongo/private/ops/run.go
@@ -10,6 +10,7 @@ import (
 	"context"
 
 	"github.com/mongodb/mongo-go-driver/bson"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 	"github.com/mongodb/mongo-go-driver/mongo/model"
 	"github.com/mongodb/mongo-go-driver/mongo/private/conn"
 	"github.com/mongodb/mongo-go-driver/mongo/private/msg"
@@ -17,10 +18,15 @@ import (
 
 // Run executes an arbitrary command against the given database.
 func Run(ctx context.Context, s *SelectedServer, db string, command interface{}) (bson.Reader, error) {
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	return runMayUseSecondary(ctx, s, db, command)
 }
 
 func runMustUsePrimary(ctx context.Context, s *SelectedServer, db string, command interface{}) (bson.Reader, error) {
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	request := msg.NewCommand(
 		msg.NextRequestID(),
@@ -39,6 +45,9 @@ func runMustUsePrimary(ctx context.Context, s *SelectedServer, db string, comman
 }
 
 func runMayUseSecondary(ctx context.Context, s *SelectedServer, db string, command interface{}) (bson.Reader, error) {
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	request := msg.NewCommand(
 		msg.NextRequestID(),
 		db,

--- a/mongo/private/ops/run_command.go
+++ b/mongo/private/ops/run_command.go
@@ -10,11 +10,15 @@ import (
 	"context"
 
 	"github.com/mongodb/mongo-go-driver/bson"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 )
 
 // RunCommand runs a command on the database.
 func RunCommand(ctx context.Context, s *SelectedServer, db string, command interface{},
 ) (bson.Reader, error) {
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	return runMustUsePrimary(ctx, s, db, command)
 }

--- a/mongo/private/ops/update.go
+++ b/mongo/private/ops/update.go
@@ -10,6 +10,7 @@ import (
 	"context"
 
 	"github.com/mongodb/mongo-go-driver/bson"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 	"github.com/mongodb/mongo-go-driver/mongo/internal"
 	"github.com/mongodb/mongo-go-driver/mongo/private/options"
 )
@@ -17,6 +18,9 @@ import (
 // Update executes an update command with a given set of update documents and options.
 func Update(ctx context.Context, s *SelectedServer, ns Namespace, updateDocs []*bson.Document,
 	opt ...options.UpdateOptioner) (bson.Reader, error) {
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	if err := ns.validate(); err != nil {
 		return nil, err


### PR DESCRIPTION
Add non-invasive tracing with OpenCensus, thankfully
because these functions had a forethought of using context.Context
so internally we just plug in:

```go
ctx, span := startSpan(ctx)
defer span.End()
```